### PR TITLE
Fix image inputs

### DIFF
--- a/packages/claude-code/src/llms/transformer/anthropic.transformer.ts
+++ b/packages/claude-code/src/llms/transformer/anthropic.transformer.ts
@@ -115,7 +115,7 @@ export class AnthropicTransformer implements Transformer {
                       image_url: {
                         url:
                           part.source?.type === "base64"
-                            ? `data:${part.source.media_type},${part.source.data}`
+                            ? `data:${part.source.media_type};base64,${part.source.data}`
                             : part.source.url,
                       },
                       media_type: part.source.media_type,


### PR DESCRIPTION
Claude Code has an error handling image attachments in the conversation.  The reason is that the base64 URL format is incorrect.