### PR TITLE
docs: README 补官网/模型目录/热门模型页深链(TASK-FEAJTJ ④)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@
 
 One Gateway, Infinite Models；one-stop request: OpenAI, Claude, Gemini, DeepSeek, Qwen, and over 500 AI models.
 
+🌐 **[aihubmix.com](https://aihubmix.com)** · 📚 **[Documentation](https://docs.aihubmix.com)** · 🧭 **[Browse all models & pricing](https://aihubmix.com/models)** · 🆓 **[Free models](https://aihubmix.com/models/free)**
+
+Popular models on AIHubMix: [Qwen3.8 Max Preview](https://aihubmix.com/model/qwen3.8-max-preview) · [Kimi K3](https://aihubmix.com/model/kimi-k3) · [GLM 5.2](https://aihubmix.com/model/glm-5.2) · [Claude Opus 5](https://aihubmix.com/model/claude-opus-5) · [Gemini 3.6 Flash](https://aihubmix.com/model/gemini-3.6-flash) · [DeepSeek V4 Flash](https://aihubmix.com/model/deepseek-v4-flash) · [Grok 4.5](https://aihubmix.com/model/grok-4.5) · [GPT-5.6 Luna](https://aihubmix.com/model/gpt-5.6-luna)
+
 ## Features
 
 ### @aihubmix/claude-code

--- a/README.zh.md
+++ b/README.zh.md
@@ -11,6 +11,10 @@
 
 One Gateway, Infinite Models；one-stop request: OpenAI, Claude, Gemini, DeepSeek, Qwen, and over 500 AI models.
 
+🌐 **[aihubmix.com](https://aihubmix.com)** · 📚 **[文档](https://docs.aihubmix.com/cn)** · 🧭 **[浏览全部模型与价格](https://aihubmix.com/models)** · 🆓 **[免费模型](https://aihubmix.com/models/free)**
+
+热门模型：[Qwen3.8 Max Preview](https://aihubmix.com/model/qwen3.8-max-preview) · [Kimi K3](https://aihubmix.com/model/kimi-k3) · [GLM 5.2](https://aihubmix.com/model/glm-5.2) · [Claude Opus 5](https://aihubmix.com/model/claude-opus-5) · [Gemini 3.6 Flash](https://aihubmix.com/model/gemini-3.6-flash) · [DeepSeek V4 Flash](https://aihubmix.com/model/deepseek-v4-flash) · [Grok 4.5](https://aihubmix.com/model/grok-4.5) · [GPT-5.6 Luna](https://aihubmix.com/model/gpt-5.6-luna)
+
 ## 功能介绍
 
 ### @aihubmix/claude-code


### PR DESCRIPTION
## 背景

TASK-FEAJTJ 第④项(GitHub 深链外链)。本仓是组织下 star 最高的公开 SDK 仓库,但 README 此前连 aihubmix.com 一个链接都没有,对用户和搜索引擎都是死胡同。

## 改动

README.md / README.zh.md 的项目介绍下补一行站点入口(官网 / 文档 / 模型目录 / 免费模型)+ 一行热门模型页深链(8 个,GSC 高曝光模型,锚文本用官方自然名)。

链接全部实测 200。

🤖 Generated with [Claude Code](https://claude.com/claude-code)